### PR TITLE
Fix /events/ not available

### DIFF
--- a/content/community-days/2024.md
+++ b/content/community-days/2024.md
@@ -2,7 +2,7 @@
 title: 'Community Days 2024'
 weight: 2
 type: 'event'
-draft: true
+draft: false
 
 params:
   event:

--- a/content/community-days/_index.md
+++ b/content/community-days/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Community days'
 type: 'event'
-draft: true
+draft: false
 ---
 <!--
   SPDX-FileCopyrightText: 2025 OASIS CSAF TC

--- a/content/events.md
+++ b/content/events.md
@@ -4,7 +4,7 @@ params:
   events:
     year: 2025
 layout: 'events'
-draft: true
+draft: false
 ---
 <!--
   SPDX-FileCopyrightText: 2025 OASIS CSAF TC

--- a/content/workshops/2024.md
+++ b/content/workshops/2024.md
@@ -2,7 +2,7 @@
 title: 'Workshop 2024'
 weight: 1
 type: 'event'
-draft: true
+draft: false
 
 params:
   event:

--- a/content/workshops/_index.md
+++ b/content/workshops/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Workshops'
 type: 'event'
-draft: true
+draft: false
 ---
 <!--
   SPDX-FileCopyrightText: 2025 OASIS CSAF TC


### PR DESCRIPTION
Resolves #15 

The reason why /events/ is not accessible is that the new pages are still in the development status and are not published (they have ‘draft: true’ in the md-files).

This commit sets draft to ‘false’ for all the new pages. They should become accessible after the merge and completion of the deployment action.