### PR TITLE
14 add tlp label

### DIFF
--- a/archetypes/community-days.md
+++ b/archetypes/community-days.md
@@ -42,7 +42,7 @@ Event description.
 
 | Time | Session | Speaker |
 | --- | --- | --- |
-| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} | Justin Murphy (CISA) |
+| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} {{< tlp-clear >}} | Justin Murphy (CISA) |
 
 ## Location
 
@@ -85,6 +85,8 @@ welcoming you to Munich!
 ## Sessions
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Welcome & Keynote
 

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -8,6 +8,7 @@
 @import 'custom/blocks/navbar';
 @import 'custom/blocks/positioning';
 @import 'custom/blocks/text';
+@import 'custom/blocks/tlp';
 @import 'custom/blocks/youtube';
 @import 'custom/pages/events';
 @import 'custom/pages/index';

--- a/assets/scss/custom/blocks/_tlp.scss
+++ b/assets/scss/custom/blocks/_tlp.scss
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+
+.tlp {
+  background-color: #000;
+  padding: 0.15rem 0.35rem;
+  margin: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: bold;
+  font-family: "Open Sans", OpenSans, sans-serif;
+  max-width: fit-content;
+  font-size: 14px;
+
+  &-red {
+    color: #FF2B2B;
+  }
+
+  &-amber {
+    color: #FFC000;
+  }
+
+  &-green {
+    color: #33FF00;
+  }
+
+  &-clear {
+    color: #FFFFFF;
+  }
+}

--- a/assets/scss/custom/pages/_events.scss
+++ b/assets/scss/custom/pages/_events.scss
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 
+.event {
+  table {
+    .tlp {
+      display: block;
+    }
+  }
+}
+
 .session-card {
+  position: relative;
   background-color: $light;
   border-left: 4px solid $accent;
   padding: 1rem;
@@ -15,6 +24,17 @@
     color: $gray-800;
     font-size: 15px;
     line-height: 1.1;
+  }
+
+  h3 {
+    margin: 0;
+    padding-right: 6.2rem;
+  }
+
+  .tlp {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
   }
 }
 

--- a/content/community-days/2024.md
+++ b/content/community-days/2024.md
@@ -39,7 +39,7 @@ for insightful talks, demos, discussions, and networking opportunities.
 
 | Time | Session | Speaker |
 | --- | --- | --- |
-| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} | Justin Murphy (CISA) |
+| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} {{< tlp-clear >}} | Justin Murphy (CISA) |
 | 13:50 - 14:20 CET | {{< internal-link "What is New in CSAF 2.1" >}} | Stefan Hagen (CSAF TC) |
 | 14:25 - 14:55 CET | {{< internal-link "Advisory, Quo Vadis?" >}} | Thomas Proell (Siemens) |
 | 15:00 - 15:30 CET | {{< internal-link "CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience" >}} | Sonny van Lingen |
@@ -135,6 +135,8 @@ system)
 ## Sessions
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Welcome & Keynote
 

--- a/content/community-days/2024.md
+++ b/content/community-days/2024.md
@@ -352,9 +352,7 @@ IntelMQ.
 
 {{< tlp-clear >}}
 
-
 ### Modernizing Vulnerability Management and Disclosure: Using CSAF in an "AI-Driven World" (Panel)
-
 
 #### Moderator: Omar Santos (CSAF TC (Chair))
 
@@ -558,7 +556,6 @@ for the company and occasionally contributes code back to the project.
 {{< /session-card >}}
 
 {{< session-card >}}
-
 
 {{< tlp-clear >}}
 

--- a/content/community-days/2024.md
+++ b/content/community-days/2024.md
@@ -40,13 +40,13 @@ for insightful talks, demos, discussions, and networking opportunities.
 | Time | Session | Speaker |
 | --- | --- | --- |
 | 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} {{< tlp-clear >}} | Justin Murphy (CISA) |
-| 13:50 - 14:20 CET | {{< internal-link "What is New in CSAF 2.1" >}} | Stefan Hagen (CSAF TC) |
-| 14:25 - 14:55 CET | {{< internal-link "Advisory, Quo Vadis?" >}} | Thomas Proell (Siemens) |
-| 15:00 - 15:30 CET | {{< internal-link "CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience" >}} | Sonny van Lingen |
+| 13:50 - 14:20 CET | {{< internal-link "What is New in CSAF 2.1" >}} {{< tlp-clear >}} | Stefan Hagen (CSAF TC) |
+| 14:25 - 14:55 CET | {{< internal-link "Advisory, Quo Vadis?" >}} {{< tlp-green >}}| Thomas Proell (Siemens) |
+| 15:00 - 15:30 CET | {{< internal-link "CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience" >}} {{< tlp-amber >}} | Sonny van Lingen |
 | 15:30 - 16:00 CET | Break |     |
-| 16:05 - 16:55 CET | {{< internal-link "CSAF Usage as Part of the EUVD and Beyond" >}} | Johannes Clos (ENISA) |
+| 16:05 - 16:55 CET | {{< internal-link "CSAF Usage as Part of the EUVD and Beyond" >}} {{< tlp-clear >}} | Johannes Clos (ENISA) |
 | 16:55 - 17:05 CET | Break |     |
-| 17:05 - 18:00 CET | {{< internal-link "Modernizing Vulnerability Management and Disclosure: Using CSAF in an \"AI-Driven World\" (Panel)" >}} | Omar Santos (CSAF TC (Chair)) and guests |
+| 17:05 - 18:00 CET | {{< internal-link "Modernizing Vulnerability Management and Disclosure: Using CSAF in an \"AI-Driven World\" (Panel)" >}} {{< tlp-clear >}}| Omar Santos (CSAF TC (Chair)) and guests |
 | 18:00 - 18:05 CET | Day 1 Wrap Up |     |
 
 **Social Gathering:** 19:00 CET at Wirtshaus Weißbräu Huber,
@@ -57,19 +57,19 @@ General-von-Nagel-Straße 5, 85356 Freising, Germany _(Location changed)_
 | Time | Session | Speaker |
 | --- | --- | --- |
 | 08:00 - 08:05 CET | Welcome and Day 1 Recap |     |
-| 08:05 - 08:35 CET | {{< internal-link "Oddities of finding and files (from an implementers view)" >}} | Bernhard Reiter (Intevation GmbH) |
-| 08:40 - 09:25 CET | {{< internal-link "OT Security in Sync: A CSAF Template Powering 40+ Vendors" >}} | Jochen Becker (CERT@VDE) |
-| 09:25 - 09:40 CET | {{< internal-link "Scaling CSAF: Building a Trusted Provider Network for 40+ Vendors" >}} | Jochen Becker (CERT@VDE) |
-| 09:45 - 10:05 CET | {{< internal-link "Correlation between CSAF and CVEs" >}} | Cédric Bonhomme (CIRCL) |
+| 08:05 - 08:35 CET | {{< internal-link "Oddities of finding and files (from an implementers view)" >}} {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
+| 08:40 - 09:25 CET | {{< internal-link "OT Security in Sync: A CSAF Template Powering 40+ Vendors" >}} {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
+| 09:25 - 09:40 CET | {{< internal-link "Scaling CSAF: Building a Trusted Provider Network for 40+ Vendors" >}} {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
+| 09:45 - 10:05 CET | {{< internal-link "Correlation between CSAF and CVEs" >}} {{< tlp-clear >}} | Cédric Bonhomme (CIRCL) |
 | 10:10 - 10:25 CET | Break |     |
-| 10:25 - 11:10 CET | {{< internal-link "VEX-supported Vulnerability Management with SecObserve" >}} | Stefan Fleckenstein & Lukas Voetmand |
-| 11:15 - 11:45 CET | {{< internal-link "Integrating the CSAF Standard into Dependency-Track with Kotlin-CSAF: Early Insights and Developments" >}} | Christian Banse |
+| 10:25 - 11:10 CET | {{< internal-link "VEX-supported Vulnerability Management with SecObserve" >}} {{< tlp-clear >}} | Stefan Fleckenstein & Lukas Voetmand |
+| 11:15 - 11:45 CET | {{< internal-link "Integrating the CSAF Standard into Dependency-Track with Kotlin-CSAF: Early Insights and Developments" >}} {{< tlp-clear >}} | Christian Banse |
 | 11:45 - 12:45 CET | Lunch |     |
-| 12:50 - 13:20 CET | {{< internal-link "Handling lots of Incoming Documents as Team with ISDuBA — a CSAF Management System Web App" >}} | Bernhard Reiter (Intevation GmbH) |
-| 13:25 - 13:55 CET | {{< internal-link "Demonstrator with CSAF-Matching from the Project ZenSIM4.0" >}} | Dr. Salva Daneshgadeh Cakmakci |
-| 14:00 - 14:45 CET | {{< internal-link "Experiences in Consuming CSAFs & What is Still Missing" >}} | Tobias Limmer & Michael Pfurtscheller |
-| 14:50 - 15:15 CET | {{< internal-link "How to get CSAF into Contracts" >}} | Thomas Schmidt (BSI) |
-| 15:20 - 15:30 CET | Closing Remarks | Omar Santos (CSAF TC (Chair)) |
+| 12:50 - 13:20 CET | {{< internal-link "Handling lots of Incoming Documents as Team with ISDuBA — a CSAF Management System Web App" >}} {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
+| 13:25 - 13:55 CET | {{< internal-link "Demonstrator with CSAF-Matching from the Project ZenSIM4.0" >}} {{< tlp-clear >}} | Dr. Salva Daneshgadeh Cakmakci |
+| 14:00 - 14:45 CET | {{< internal-link "Experiences in Consuming CSAFs & What is Still Missing" >}} {{< tlp-clear >}} | Tobias Limmer & Michael Pfurtscheller |
+| 14:50 - 15:15 CET | {{< internal-link "How to get CSAF into Contracts" >}} {{< tlp-clear >}} | Thomas Schmidt (BSI) |
+| 15:20 - 15:30 CET | Closing Remarks {{< tlp-clear >}} | Omar Santos (CSAF TC (Chair)) |
 
 ## Location
 
@@ -162,14 +162,16 @@ Statistics from the University of Tennessee (Knoxville).
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### What is New in CSAF 2.1
 
 #### Speaker: Stefan Hagen (CSAF TC)
 
 **Abstract:** The talk presents scheduled changes in CSAF v2.1 as compared to
 CSAF v2.0. In addition to naming, the changes are motivated. Examples
-demonstrate what may be achieved with CSAF v2.1 that is not - or not as easily
-- possible with CSAF v2.0. Scenarios are presented as examples on why and how
+demonstrate what may be achieved with CSAF v2.1 that is not - or not as easily -
+possible with CSAF v2.0. Scenarios are presented as examples on why and how
 to migrate CSAF v2.0 content to CSAF v2.1.
 
 **Bio:** Stefan Hagen studied physics at the University of Bonn. He is a senior
@@ -183,6 +185,8 @@ ground-based training systems in a Swiss aircraft factory.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-green >}}
 
 ### Advisory, Quo Vadis?
 
@@ -219,6 +223,8 @@ gathered a clear understanding what the upcoming challenges will come.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-amber >}}
 
 ### CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience
 
@@ -270,6 +276,8 @@ University and holds several security certifications such as CISSP and CISA.
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### Correlation between CSAF and CVEs
 
 #### Speaker: Cédric Bonhomme (CIRCL)
@@ -314,6 +322,8 @@ and open-source software projects.
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### CSAF Usage as Part of the EUVD and Beyond
 
 #### Speaker: Johannes Clos (ENISA)
@@ -339,6 +349,8 @@ IntelMQ.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Modernizing Vulnerability Management and Disclosure: Using CSAF in an
 "AI-Driven World" (Panel)
@@ -374,6 +386,8 @@ cybersecurity is also recognized through multiple granted patents.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Oddities of finding and files (from an implementers view)
 
@@ -416,6 +430,8 @@ https://intevation.de/~bernhard/index.en.html
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### OT Security in Sync: A CSAF Template Powering 40+ Vendors
 
 #### Speaker: Jochen Becker (CERT@VDE)
@@ -452,6 +468,8 @@ that even today the soldering iron should not be too far away from the keyboard.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Scaling CSAF: Building a Trusted Provider Network for 40+ Vendors
 
@@ -491,6 +509,8 @@ the goggles of his FPV-quadcopter.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### VEX-supported Vulnerability Management with SecObserve
 
@@ -538,6 +558,8 @@ for the company and occasionally contributes code back to the project.
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### Integrating the CSAF Standard into Dependency-Track with Kotlin-CSAF: Early
 Insights and Developments
 
@@ -580,6 +602,8 @@ ensuring robust defenses against emerging threats.
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### Handling lots of Incoming Documents as Team with ISDuBA — a CSAF
 Management System Web App
 
@@ -621,6 +645,8 @@ https://intevation.de/~bernhard/index.en.html
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### Demonstrator with CSAF-Matching from the Project ZenSIM4.0
 
@@ -673,6 +699,8 @@ Threat (APT) detection.
 
 {{< session-card >}}
 
+{{< tlp-clear >}}
+
 ### Experiences in Consuming CSAFs & What is Still Missing
 
 #### Speaker: Tobias Limmer & Michael Pfurtscheller
@@ -711,6 +739,8 @@ vulnerability, incident, and update management for its modules and firmware.
 {{< /session-card >}}
 
 {{< session-card >}}
+
+{{< tlp-clear >}}
 
 ### How to get CSAF into Contracts
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -534,6 +534,42 @@ Example:
 
 ---
 
+#### TLP:Label
+
+5 tags that insert TLP labes with proper styling:
+
+```markdown
+{{< tlp-red >}}
+{{< tlp-amber >}}
+{{< tlp-amber-strict >}}
+{{< tlp-green >}}
+{{< tlp-clear >}}
+```
+
+**Examples**
+
+In the table of contents: within the table cell.
+
+```markdown
+| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} {{< tlp-clear >}} | Justin Murphy (CISA) |
+```
+
+In the seccion card: after the opening `{{< session-card >}}` tag
+and before the heading.
+
+```markdown
+{{< session-card >}}
+
+{{< tlp-clear >}}
+
+### Welcome & Keynote
+
+...
+{{< /session-card >}}
+```
+
+---
+
 ## Publishing a Page
 
 When the page is ready to go live, set `draft` to `false`

--- a/layouts/event/single.html
+++ b/layouts/event/single.html
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: Apache-2.0
   SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 -->
-<main class="md bg-light">
+<main class="event md bg-light">
   <!-- #region: Title -->
   {{ $bg := .Params.render.images.header }}
   <section {{ if $bg }}style="background: url('{{ $bg }}') no-repeat center/cover;"{{ else }}class="blue-gradient"{{ end }}>

--- a/layouts/shortcodes/tlp-amber-strict.html
+++ b/layouts/shortcodes/tlp-amber-strict.html
@@ -1,0 +1,1 @@
+<span class="tlp tlp-amber">TLP:AMBER+STRICT</span>

--- a/layouts/shortcodes/tlp-amber.html
+++ b/layouts/shortcodes/tlp-amber.html
@@ -1,0 +1,1 @@
+<span class="tlp tlp-amber">TLP:AMBER</span>

--- a/layouts/shortcodes/tlp-clear.html
+++ b/layouts/shortcodes/tlp-clear.html
@@ -1,0 +1,1 @@
+<span class="tlp tlp-clear">TLP:CLEAR</span>

--- a/layouts/shortcodes/tlp-green.html
+++ b/layouts/shortcodes/tlp-green.html
@@ -1,0 +1,1 @@
+<span class="tlp tlp-green">TLP:GREEN</span>

--- a/layouts/shortcodes/tlp-red.html
+++ b/layouts/shortcodes/tlp-red.html
@@ -1,0 +1,1 @@
+<span class="tlp tlp-red">TLP:RED</span>


### PR DESCRIPTION
Closes #14 

- In the tables label is displayed in it's own line within the same cell. In the example - under the presentation title.
- Technically, the label can be in any place between the session-card opening and closing tags. But in the docs I've suggested the strict position (between the opening tag and header) to maintain more clear stucture. 
- Labels are compatible with long headers inside of the section-cards: if header is too long, it wraps before the tag.
- I've already added the first tag to the community days 2024 as an example.