### PR TITLE
TLP Labels

### DIFF
--- a/content/community-days/2024.md
+++ b/content/community-days/2024.md
@@ -37,39 +37,39 @@ for insightful talks, demos, discussions, and networking opportunities.
 
 ### CSAF Community Day 1 (December 12, 2024)
 
-| Time | Session | Speaker |
-| --- | --- | --- |
-| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} {{< tlp-clear >}} | Justin Murphy (CISA) |
-| 13:50 - 14:20 CET | {{< internal-link "What is New in CSAF 2.1" >}} {{< tlp-clear >}} | Stefan Hagen (CSAF TC) |
-| 14:25 - 14:55 CET | {{< internal-link "Advisory, Quo Vadis?" >}} {{< tlp-green >}}| Thomas Proell (Siemens) |
-| 15:00 - 15:30 CET | {{< internal-link "CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience" >}} {{< tlp-amber >}} | Sonny van Lingen |
-| 15:30 - 16:00 CET | Break |     |
-| 16:05 - 16:55 CET | {{< internal-link "CSAF Usage as Part of the EUVD and Beyond" >}} {{< tlp-clear >}} | Johannes Clos (ENISA) |
-| 16:55 - 17:05 CET | Break |     |
-| 17:05 - 18:00 CET | {{< internal-link "Modernizing Vulnerability Management and Disclosure: Using CSAF in an \"AI-Driven World\" (Panel)" >}} {{< tlp-clear >}}| Omar Santos (CSAF TC (Chair)) and guests |
-| 18:00 - 18:05 CET | Day 1 Wrap Up |     |
+| Time | Session | TLP |Speaker |
+| --- | --- | --- | --- |
+| 13:30 - 13:45 CET | {{< internal-link "Welcome & Keynote" >}} | {{< tlp-clear >}} | Justin Murphy (CISA) |
+| 13:50 - 14:20 CET | {{< internal-link "What is New in CSAF 2.1" >}} | {{< tlp-clear >}} | Stefan Hagen (CSAF TC) |
+| 14:25 - 14:55 CET | {{< internal-link "Advisory, Quo Vadis?" >}} |  {{< tlp-green >}}| Thomas Proell (Siemens) |
+| 15:00 - 15:30 CET | {{< internal-link "CSAF Trusted Provider - Huawei Solution, Progress and Sharing of Experience" >}} | {{< tlp-amber >}} | Sonny van Lingen |
+| 15:30 - 16:00 CET | Break | |     |
+| 16:05 - 16:55 CET | {{< internal-link "CSAF Usage as Part of the EUVD and Beyond" >}} | {{< tlp-clear >}} | Johannes Clos (ENISA) |
+| 16:55 - 17:05 CET | Break | |    |
+| 17:05 - 18:00 CET | {{< internal-link "Modernizing Vulnerability Management and Disclosure: Using CSAF in an \"AI-Driven World\" (Panel)" >}} | {{< tlp-clear >}}| Omar Santos (CSAF TC (Chair)) and guests |
+| 18:00 - 18:05 CET | Day 1 Wrap Up | {{< tlp-clear >}} |    |
 
 **Social Gathering:** 19:00 CET at Wirtshaus Weißbräu Huber,
 General-von-Nagel-Straße 5, 85356 Freising, Germany _(Location changed)_
 
 ### CSAF Community Day 2 (December 13, 2024)
 
-| Time | Session | Speaker |
-| --- | --- | --- |
-| 08:00 - 08:05 CET | Welcome and Day 1 Recap |     |
-| 08:05 - 08:35 CET | {{< internal-link "Oddities of finding and files (from an implementers view)" >}} {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
-| 08:40 - 09:25 CET | {{< internal-link "OT Security in Sync: A CSAF Template Powering 40+ Vendors" >}} {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
-| 09:25 - 09:40 CET | {{< internal-link "Scaling CSAF: Building a Trusted Provider Network for 40+ Vendors" >}} {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
-| 09:45 - 10:05 CET | {{< internal-link "Correlation between CSAF and CVEs" >}} {{< tlp-clear >}} | Cédric Bonhomme (CIRCL) |
+| Time | Session | TLP | Speaker |
+| --- | --- | --- | --- |
+| 08:00 - 08:05 CET | Welcome and Day 1 Recap | {{< tlp-clear >}} |     |
+| 08:05 - 08:35 CET | {{< internal-link "Oddities of finding and files (from an implementers view)" >}} | {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
+| 08:40 - 09:25 CET | {{< internal-link "OT Security in Sync: A CSAF Template Powering 40+ Vendors" >}} | {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
+| 09:25 - 09:40 CET | {{< internal-link "Scaling CSAF: Building a Trusted Provider Network for 40+ Vendors" >}} | {{< tlp-clear >}} | Jochen Becker (CERT@VDE) |
+| 09:45 - 10:05 CET | {{< internal-link "Correlation between CSAF and CVEs" >}} | {{< tlp-clear >}} | Cédric Bonhomme (CIRCL) |
 | 10:10 - 10:25 CET | Break |     |
-| 10:25 - 11:10 CET | {{< internal-link "VEX-supported Vulnerability Management with SecObserve" >}} {{< tlp-clear >}} | Stefan Fleckenstein & Lukas Voetmand |
-| 11:15 - 11:45 CET | {{< internal-link "Integrating the CSAF Standard into Dependency-Track with Kotlin-CSAF: Early Insights and Developments" >}} {{< tlp-clear >}} | Christian Banse |
+| 10:25 - 11:10 CET | {{< internal-link "VEX-supported Vulnerability Management with SecObserve" >}} | {{< tlp-clear >}} | Stefan Fleckenstein & Lukas Voetmand |
+| 11:15 - 11:45 CET | {{< internal-link "Integrating the CSAF Standard into Dependency-Track with Kotlin-CSAF: Early Insights and Developments" >}} | {{< tlp-clear >}} | Christian Banse |
 | 11:45 - 12:45 CET | Lunch |     |
-| 12:50 - 13:20 CET | {{< internal-link "Handling lots of Incoming Documents as Team with ISDuBA — a CSAF Management System Web App" >}} {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
-| 13:25 - 13:55 CET | {{< internal-link "Demonstrator with CSAF-Matching from the Project ZenSIM4.0" >}} {{< tlp-clear >}} | Dr. Salva Daneshgadeh Cakmakci |
-| 14:00 - 14:45 CET | {{< internal-link "Experiences in Consuming CSAFs & What is Still Missing" >}} {{< tlp-clear >}} | Tobias Limmer & Michael Pfurtscheller |
-| 14:50 - 15:15 CET | {{< internal-link "How to get CSAF into Contracts" >}} {{< tlp-clear >}} | Thomas Schmidt (BSI) |
-| 15:20 - 15:30 CET | Closing Remarks {{< tlp-clear >}} | Omar Santos (CSAF TC (Chair)) |
+| 12:50 - 13:20 CET | {{< internal-link "Handling lots of Incoming Documents as Team with ISDuBA — a CSAF Management System Web App" >}} | {{< tlp-clear >}} | Bernhard Reiter (Intevation GmbH) |
+| 13:25 - 13:55 CET | {{< internal-link "Demonstrator with CSAF-Matching from the Project ZenSIM4.0" >}} | {{< tlp-clear >}} | Dr. Salva Daneshgadeh Cakmakci |
+| 14:00 - 14:45 CET | {{< internal-link "Experiences in Consuming CSAFs & What is Still Missing" >}} | {{< tlp-clear >}} | Tobias Limmer & Michael Pfurtscheller |
+| 14:50 - 15:15 CET | {{< internal-link "How to get CSAF into Contracts" >}} | {{< tlp-clear >}} | Thomas Schmidt (BSI) |
+| 15:20 - 15:30 CET | Closing Remarks | {{< tlp-clear >}} | Omar Santos (CSAF TC (Chair)) |
 
 ## Location
 


### PR DESCRIPTION
- addresses parts of csaf-auxiliary/csaf-website-relaunch#14
- move TLP to extra column
- add missing labels for opening and wrap-up